### PR TITLE
Override default user agent styles for `<button>` elements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,26 @@
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    --color: #111;
+
+    color: var(--color);
+}
+
+button[role="tab"] {
+    padding: 0.25rem;
+    font-size: 1rem;
+    color: var(--color);
+    background-color: #efefef;
+
+    + button[role="tab"] {
+        margin-inline-start: 0.125rem;
+    }
+
+    &:focus-visible {
+        outline: 0.125rem solid var(--color);
+    }
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Tabs Element (based on "Tabs Pattern | APG | WAI | W3C")</title>
+
+    <link rel="stylesheet" href="assets/css/style.css">
 </head>
 
 <body>


### PR DESCRIPTION
To ensure that they meet certain WCAG (Web Content Accessibility Guidelines) requirements:
1. Sufficient target size (a minimum of 24px by 24px)
2. Sufficient text contrast (a minimum of 4.500:1 for text against its background).